### PR TITLE
remove jquery as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "url": "https://github.com/skidding/flatris.git"
   },
   "dependencies": {
-    "jquery": "^3.1.1",
     "lodash": "^4.17.4",
     "raf": "^3.3.0",
     "react": "^15.4.2",

--- a/src/components/FlatrisGame.jsx
+++ b/src/components/FlatrisGame.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import _ from 'lodash';
-import $ from 'jquery';
 import { STOPPED, PLAYING, PAUSED } from '../constants/states';
 import { UP, DOWN, LEFT, RIGHT } from '../constants/keys';
 import { attachPointerDownEvent, attachPointerUpEvent } from '../lib/events';
@@ -43,15 +42,15 @@ class FlatrisGame extends React.Component {
   }
 
   componentDidMount() {
-    $(window).on('keydown', this.onKeyDown);
-    $(window).on('keyup', this.onKeyUp);
+    window.addEventListener('keydown', this.onKeyDown);
+    window.addEventListener('keyup', this.onKeyUp);
 
     this.props.onLoad();
   }
 
   componentWillUnmount() {
-    $(window).off('keydown', this.onKeyDown);
-    $(window).off('keyup', this.onKeyUp);
+    window.removeEventListener('keydown', this.onKeyDown);
+    window.removeEventListener('keyup', this.onKeyUp);
   }
 
   onKeyDown(e) {


### PR DESCRIPTION
Removed JQuery as a dependency as you can use standard JavaScript to add and remove event listeners to an element. Doing this also saves ~85kb in the final build!